### PR TITLE
limit composition to area composed when composite image

### DIFF
--- a/src/ngx_http_small_light_imagemagick.c
+++ b/src/ngx_http_small_light_imagemagick.c
@@ -346,7 +346,7 @@ ngx_int_t ngx_http_small_light_imagemagick_process(
             canvas_wand,
             ictx->wand,
             AtopCompositeOp,
-            MagickFalse,
+            MagickTrue,
             sz.dx,
             sz.dy
         );


### PR DESCRIPTION
When composite an image on the canvas for cropping , the original image will fill the canvas that made the image broken

Before : 

![Screen Shot 2023-07-21 at 2 33 44 PM](https://github.com/midorinet/ngx_small_light/assets/2119356/58ef8794-9fa0-4ab5-94bc-3b9332f1655c)


After patch ( same as old verison with imagick 6)
![Screen Shot 2023-07-21 at 2 34 34 PM](https://github.com/midorinet/ngx_small_light/assets/2119356/11622cd3-41bb-491c-9b37-ae40e5f2f0bc)
